### PR TITLE
Allow rollbar.js to filter client urls by a regex

### DIFF
--- a/lib/smoke_detector/providers/provider.rb
+++ b/lib/smoke_detector/providers/provider.rb
@@ -4,7 +4,8 @@ module SmokeDetector::Providers
     attr_accessor :controller_proc
 
     def initialize(api_key, client_api_key = nil, settings = {})
-      @client_api_key = client_api_key
+      @client_api_key          = client_api_key
+      @js_url_filter = settings.delete(:js_url_filter)
     end
 
     def alert(exception, options = {})

--- a/lib/smoke_detector/providers/provider.rb
+++ b/lib/smoke_detector/providers/provider.rb
@@ -4,8 +4,8 @@ module SmokeDetector::Providers
     attr_accessor :controller_proc
 
     def initialize(api_key, client_api_key = nil, settings = {})
-      @client_api_key          = client_api_key
-      @js_url_filter = settings.delete(:js_url_filter)
+      @client_api_key = client_api_key
+      @js_url_filter  = settings.delete(:js_url_filter)
     end
 
     def alert(exception, options = {})

--- a/lib/smoke_detector/providers/rollbar.rb
+++ b/lib/smoke_detector/providers/rollbar.rb
@@ -35,6 +35,7 @@ module SmokeDetector::Providers
       return '' if client_api_key.blank?
       @client_monitoring_code ||= <<-JS
         <script>
+          #{url_filter_snippet}
           var _rollbarConfig = {
               accessToken: "#{@client_api_key}",
               captureUncaught: true,
@@ -42,9 +43,31 @@ module SmokeDetector::Providers
                   environment: "#{::Rails.env}"
               }
           };
+          if(typeof(ignoreRemoteUncaught) === 'function'){
+            _rollbarConfig['checkIgnore'] = ignoreRemoteUncaught;
+          }
           !function(a,b){function c(b){this.shimId=++f,this.notifier=null,this.parentShim=b,this.logger=function(){},a.console&&void 0===a.console.shimId&&(this.logger=a.console.log)}function d(b){var d=c;return e(function(){if(this.notifier)return this.notifier[b].apply(this.notifier,arguments);var c=this,e="scope"===b;e&&(c=new d(this));var f=Array.prototype.slice.call(arguments,0),g={shim:c,method:b,args:f,ts:new Date};return a._rollbarShimQueue.push(g),e?c:void 0})}function e(a,b){return b=b||this.logger,function(){try{return a.apply(this,arguments)}catch(c){b("Rollbar internal error:",c)}}}var f=0;c.init=function(a,b){var d=b.globalAlias||"Rollbar";if("object"==typeof a[d])return a[d];a._rollbarShimQueue=[],b=b||{};var f=new c;return e(function(){if(f.configure(b),b.captureUncaught){var c=a.onerror;a.onerror=function(){f.uncaughtError.apply(f,arguments),c&&c.apply(a,arguments)}}return a[d]=f,f},f.logger)()},c.prototype.loadFull=function(a,b,c,d){var f=e(function(){var a=b.createElement("script"),e=b.getElementsByTagName("script")[0];a.src=d.rollbarJsUrl,a.async=!c,a.onload=g,e.parentNode.insertBefore(a,e)},this.logger),g=e(function(){if(void 0===a._rollbarPayloadQueue)for(var b,c,d,e,f=new Error("rollbar.js did not load");b=a._rollbarShimQueue.shift();)for(d=b.args,e=0;e<d.length;++e)if(c=d[e],"function"==typeof c){c(f);break}},this.logger);e(function(){c?f():a.addEventListener?a.addEventListener("load",f,!1):a.attachEvent("onload",f)},this.logger)()};for(var g="log,debug,info,warn,warning,error,critical,global,configure,scope,uncaughtError".split(","),h=0;h<g.length;++h)c.prototype[g[h]]=d(g[h]);var i="//d37gvrvc0wt4s1.cloudfront.net/js/v1.0/rollbar.min.js";_rollbarConfig.rollbarJsUrl=_rollbarConfig.rollbarJsUrl||i;var j=c.init(a,_rollbarConfig);j.loadFull(a,b,!1,_rollbarConfig)}(window,document);
         </script>
       JS
+    end
+
+    def url_filter_snippet
+      unless @js_url_filter.blank?
+        <<-JS
+        function ignoreRemoteUncaught(isUncaught, args, payload) {
+          try {
+            var filename = payload.data.body.trace.frames[0].filename;
+            if (isUncaught && !filename.match(/#{@js_url_filter}/)) {
+              // Ignore uncaught errors that are not matching js_url_filter
+              return true;
+            }
+          } catch (e) {
+            // Most likely there was no filename or the frame doesn't exist.
+          }
+          return false;
+        }
+        JS
+      end
     end
 
     module ControllerMethods

--- a/lib/smoke_detector/providers/rollbar.rb
+++ b/lib/smoke_detector/providers/rollbar.rb
@@ -35,7 +35,6 @@ module SmokeDetector::Providers
       return '' if client_api_key.blank?
       @client_monitoring_code ||= <<-JS
         <script>
-          #{url_filter_snippet}
           var _rollbarConfig = {
               accessToken: "#{@client_api_key}",
               captureUncaught: true,
@@ -43,9 +42,7 @@ module SmokeDetector::Providers
                   environment: "#{::Rails.env}"
               }
           };
-          if(typeof(ignoreRemoteUncaught) === 'function'){
-            _rollbarConfig['checkIgnore'] = ignoreRemoteUncaught;
-          }
+          #{url_filter_snippet}
           !function(a,b){function c(b){this.shimId=++f,this.notifier=null,this.parentShim=b,this.logger=function(){},a.console&&void 0===a.console.shimId&&(this.logger=a.console.log)}function d(b){var d=c;return e(function(){if(this.notifier)return this.notifier[b].apply(this.notifier,arguments);var c=this,e="scope"===b;e&&(c=new d(this));var f=Array.prototype.slice.call(arguments,0),g={shim:c,method:b,args:f,ts:new Date};return a._rollbarShimQueue.push(g),e?c:void 0})}function e(a,b){return b=b||this.logger,function(){try{return a.apply(this,arguments)}catch(c){b("Rollbar internal error:",c)}}}var f=0;c.init=function(a,b){var d=b.globalAlias||"Rollbar";if("object"==typeof a[d])return a[d];a._rollbarShimQueue=[],b=b||{};var f=new c;return e(function(){if(f.configure(b),b.captureUncaught){var c=a.onerror;a.onerror=function(){f.uncaughtError.apply(f,arguments),c&&c.apply(a,arguments)}}return a[d]=f,f},f.logger)()},c.prototype.loadFull=function(a,b,c,d){var f=e(function(){var a=b.createElement("script"),e=b.getElementsByTagName("script")[0];a.src=d.rollbarJsUrl,a.async=!c,a.onload=g,e.parentNode.insertBefore(a,e)},this.logger),g=e(function(){if(void 0===a._rollbarPayloadQueue)for(var b,c,d,e,f=new Error("rollbar.js did not load");b=a._rollbarShimQueue.shift();)for(d=b.args,e=0;e<d.length;++e)if(c=d[e],"function"==typeof c){c(f);break}},this.logger);e(function(){c?f():a.addEventListener?a.addEventListener("load",f,!1):a.attachEvent("onload",f)},this.logger)()};for(var g="log,debug,info,warn,warning,error,critical,global,configure,scope,uncaughtError".split(","),h=0;h<g.length;++h)c.prototype[g[h]]=d(g[h]);var i="//d37gvrvc0wt4s1.cloudfront.net/js/v1.0/rollbar.min.js";_rollbarConfig.rollbarJsUrl=_rollbarConfig.rollbarJsUrl||i;var j=c.init(a,_rollbarConfig);j.loadFull(a,b,!1,_rollbarConfig)}(window,document);
         </script>
       JS
@@ -54,18 +51,15 @@ module SmokeDetector::Providers
     def url_filter_snippet
       unless @js_url_filter.blank?
         <<-JS
-        function ignoreRemoteUncaught(isUncaught, args, payload) {
+        _rollbarConfig.checkIgnore = function(isUncaught, args, payload) {
           try {
             var filename = payload.data.body.trace.frames[0].filename;
             if (isUncaught && !filename.match(/#{@js_url_filter}/)) {
-              // Ignore uncaught errors that are not matching js_url_filter
               return true;
             }
-          } catch (e) {
-            // Most likely there was no filename or the frame doesn't exist.
-          }
+          } catch (e) {}
           return false;
-        }
+        };
         JS
       end
     end

--- a/spec/dummy/config/initializers/smoke_detector.rb
+++ b/spec/dummy/config/initializers/smoke_detector.rb
@@ -9,7 +9,8 @@ module SmokeDetector
         api_key: 'fake_rollbar',
         client_api_key: 'fake_rollbar_client',
         settings: {
-          use_async: true
+          use_async: true,
+          js_url_filter: '^https?:\/\/.*localhost.*'
         }
       },
       {

--- a/spec/requests/middleware/javascript_monitors_spec.rb
+++ b/spec/requests/middleware/javascript_monitors_spec.rb
@@ -26,7 +26,7 @@ describe SmokeDetector::JavaScriptMonitors do
 
     it 'does not inject url filtering code' do
       get '/widgets'
-      expect(Nokogiri::HTML(response.body).css('head script:contains("function ignoreRemoteUncaught")')).to be_empty
+      expect(Nokogiri::HTML(response.body).css('head script:contains("_rollbarConfig.checkIgnore")')).to be_empty
     end
 
     context 'with url filtering enabled' do
@@ -34,7 +34,7 @@ describe SmokeDetector::JavaScriptMonitors do
 
       it 'injects the Rollbar JS snippet into the <head>' do
         get '/widgets'
-        expect(Nokogiri::HTML(response.body).css('head script:contains("function ignoreRemoteUncaught")')).to_not be_empty
+        expect(Nokogiri::HTML(response.body).css('head script:contains("_rollbarConfig.checkIgnore")')).to_not be_empty
       end
     end
   end


### PR DESCRIPTION
@linedotstar Giving this url filtering a shot for rollbar.js. 

Just supply a regex string to the config and it will inject more code into the rollbar head script.
