### PR TITLE
Bump to Rollbar 1.2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    smoke_detector (1.0.0)
+    smoke_detector (1.1.0)
       airbrake (~> 3.1.8)
       rails (~> 3.2.12)
-      rollbar (~> 1.0.0)
+      rollbar (~> 1.2.7)
 
 GEM
   remote: http://rubygems.org/
@@ -107,7 +107,7 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    rollbar (1.0.0)
+    rollbar (1.2.7)
       multi_json (~> 1.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -136,7 +136,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.41)
+    tzinfo (0.3.42)
 
 PLATFORMS
   ruby

--- a/lib/smoke_detector/providers/rollbar.rb
+++ b/lib/smoke_detector/providers/rollbar.rb
@@ -27,12 +27,12 @@ module SmokeDetector::Providers
         exception.message << data.to_s
       end
 
-      ::Rollbar.report_exception(exception)
+      ::Rollbar.error(exception)
     end
 
     def message(message, options = {})
       level = options.delete(:level) || 'info'
-      ::Rollbar.report_message(message, level, options)
+      ::Rollbar.log(level, message, options)
     end
 
     def default_client_settings
@@ -60,7 +60,7 @@ module SmokeDetector::Providers
           exception.message << data.to_s
         end
 
-        ::Rollbar.report_exception(exception, rollbar_request_data, rollbar_person_data)
+        ::Rollbar.error(exception, rollbar_request_data, rollbar_person_data)
       end
     end
 

--- a/smoke_detector.gemspec
+++ b/smoke_detector.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails",       "~> 3.2.12"
   s.add_dependency "airbrake",    "~> 3.1.8"
-  s.add_dependency "rollbar",     "~> 1.0.0"
+  s.add_dependency "rollbar",     "~> 1.2.7"
 
   s.add_development_dependency "jshintrb"
   s.add_development_dependency "nokogiri"

--- a/spec/models/providers/rollbar_spec.rb
+++ b/spec/models/providers/rollbar_spec.rb
@@ -28,7 +28,7 @@ describe SmokeDetector::Providers::Rollbar do
 
   describe '#alert' do
     it 'reports the exception to Rollbar' do
-      Rollbar.should_receive(:report_exception).with(err)
+      Rollbar.should_receive(:error).with(err)
       provider.alert(err)
     end
 
@@ -47,7 +47,7 @@ describe SmokeDetector::Providers::Rollbar do
     let(:options) { {} }
 
     it 'reports the message to Rollbar' do
-      Rollbar.should_receive(:report_message).with(message, level, options)
+      Rollbar.should_receive(:log).with(level, message, options)
       provider.message(message)
     end
 
@@ -55,7 +55,7 @@ describe SmokeDetector::Providers::Rollbar do
       let(:options) { {custom: :data} }
 
       it 'passes the options along as the data param' do
-        Rollbar.should_receive(:report_message).with(message, level, options)
+        Rollbar.should_receive(:log).with(level, message, options)
         provider.message(message, options)
       end
 
@@ -64,12 +64,12 @@ describe SmokeDetector::Providers::Rollbar do
         let(:options) { {custom: :data, level: level} }
 
         it 'sets the message level' do
-          Rollbar.should_receive(:report_message).with(message, level, options)
+          Rollbar.should_receive(:log).with(level, message, options)
           provider.message(message, options)
         end
 
         it 'does not include the level in the data param' do
-          Rollbar.should_receive(:report_message).with(message, level, options)
+          Rollbar.should_receive(:log).with(level, message, options)
           provider.message(message, options)
         end
       end
@@ -85,7 +85,7 @@ describe SmokeDetector::Providers::Rollbar do
 
     describe '#alert_smoke_detector' do
       it 'notifies Rollbar of the exception' do
-        Rollbar.should_receive(:report_exception)
+        Rollbar.should_receive(:error)
         controller.should_receive(:rollbar_request_data)
         controller.should_receive(:rollbar_person_data)
         controller.alert_smoke_detector(err)

--- a/spec/support/shared_examples_for_providers.rb
+++ b/spec/support/shared_examples_for_providers.rb
@@ -32,28 +32,28 @@ end
 shared_examples_for 'Rollbar integrated error handler' do
   context 'uncaught in a controller' do
     it 'reports the error to Rollbar' do
-      Rollbar.should_receive(:report_exception).and_return({})
+      Rollbar.should_receive(:log).with('error', instance_of(RuntimeError)).and_return({})
       expect { get '/widgets/bubble_up' }.to raise_error(RuntimeError, 'bubble_up')
     end
   end
 
   context 'caught and reported in a controller' do
     it 'reports the error to Rollbar' do
-      Rollbar.should_receive(:report_exception)
+      Rollbar.should_receive(:error)
       expect { get '/widgets/catch' }.not_to raise_error
     end
   end
 
   context 'uncaught in a model' do
     it 'reports the error to Rollbar' do
-      Rollbar.should_receive(:report_exception).and_return({})
+      Rollbar.should_receive(:log).with('error', instance_of(RuntimeError)).and_return({})
       expect { get '/widgets/deep_bubble_up' }.to raise_error(RuntimeError, 'deep_bubble_up')
     end
   end
 
   context 'caught and reported in a model' do
     it 'reports the error to Rollbar' do
-      Rollbar.should_receive(:report_exception)
+      Rollbar.should_receive(:error)
       expect { get '/widgets/deep_catch' }.not_to raise_error
     end
   end


### PR DESCRIPTION
We're currently using the Rollbar gem directly in lumos_rosette, and when I tried adding it to our rails UI, I realized that Rollbar refactored some stuff wrt how you use the Notifier. I still need to check to see how this works out with lumos rails, but the bump seemed pretty straightforward.

cc: @camertron 
