### PR TITLE
Loosen rails dep

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    smoke_detector (2.0.0)
+    smoke_detector (2.0.1)
       airbrake (~> 3.1.8)
-      rails (~> 4.0.0)
+      rails (~> 4.0)
       rollbar (~> 1.4.0)
 
 GEM
@@ -58,7 +58,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.5)
+    mime-types (2.6.2)
     mini_portile (0.5.1)
     minitest (4.7.5)
     multi_json (1.11.0)
@@ -112,9 +112,9 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     slop (3.4.6)
-    sprockets (3.0.3)
-      rack (~> 1.0)
-    sprockets-rails (2.2.4)
+    sprockets (3.4.0)
+      rack (> 1, < 3)
+    sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)

--- a/lib/smoke_detector/version.rb
+++ b/lib/smoke_detector/version.rb
@@ -1,3 +1,3 @@
 module SmokeDetector
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/smoke_detector.gemspec
+++ b/smoke_detector.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails",       "~> 4.0.0"
+  s.add_dependency "rails",       "~> 4.0"
   s.add_dependency "airbrake",    "~> 3.1.8"
   s.add_dependency "rollbar",     "~> 1.4.0"
 


### PR DESCRIPTION
@jdoconnor for whatever reason rails here is locked down to a patch version. We're trying to use rails 4.2 with lumosity party and this gem was causing problems (we're not using smoke_detector, but we're using lumos_utils which depends on it)